### PR TITLE
Ensures that formatting happens last if the handlebars hash does not iterate in the order written

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -21,16 +21,24 @@ module.exports.register = function (Handlebars, options, params) {
       context = undefined;
     }
     var date = moment(context);
+    var hasFormat = false;
 
     // Reset the language back to default before doing anything else
     date.lang('en');
 
     for (var i in block.hash) {
-      if (date[i]) {
+      if (i === 'format') {
+        hasFormat = true;
+      }
+      else if (date[i]) {
         date = date[i](block.hash[i]);
       } else {
         console.log('moment.js does not support "' + i + '"');
       }
+    }
+
+    if (hasFormat) {
+      date = date.format(block.hash.format);
     }
     return date;
   });
@@ -41,16 +49,24 @@ module.exports.register = function (Handlebars, options, params) {
       context = 0;
     }
     var duration = moment.duration(context);
+    var hasFormat = false;
 
     // Reset the language back to default before doing anything else
     duration = duration.lang('en');
 
     for (var i in block.hash) {
-      if (duration[i]) {
+      if (i === 'format') {
+        hasFormat = true;
+      }
+      else if (duration[i]) {
         duration = duration[i](block.hash[i]);
       } else {
         console.log('moment.js duration does not support "' + i + '"');
       }
+    }
+
+    if (hasFormat) {
+      duration = duration.format(block.hash.format);
     }
     return duration;
   });


### PR DESCRIPTION
This pull request fixes a problem where formatting could happen before other operations, causing those operations to be ignored. I am not sure what causes the object keys to iterate in an order other than written, but that could cause a lot of issues – this was an easy one to fix and the particular issue that bit me. Of course the iteration order of object keys is not guaranteed but it generally holds true to the order added, maybe handlebars (4.0.5) is doing something odd behind the scenes.

I encountered this problem when using `{{moment add=period_info format="MMMM D"}}` to add time to the current date. In this case, `period_info` can have values such as `{ days: 31 }` or `{ months: 1 }`. In my case, the formatting was done first against the current date, followed by `moment.js does not support "add"` since `date` was now a string rather than a moment object. I have not noticed this problem with simpler constructs.