### PR TITLE
Replace 'lodash' with 'lodash.cloneDeep'

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -12,12 +12,12 @@
 /*jshint node:true */
 'use strict';
 module.exports.register = function (Handlebars, options, params) {
-  var moment  = require('moment-timezone');
-  var _       = require('lodash');
+  var moment    = require('moment-timezone');
+  var cloneDeep = require('lodash.clonedeep');
 
   Handlebars.registerHelper('moment', function (context, block) {
     if (context && context.hash) {
-      block = _.cloneDeep(context);
+      block = cloneDeep(context);
       context = undefined;
     }
     var date = moment(context);
@@ -50,7 +50,7 @@ module.exports.register = function (Handlebars, options, params) {
 
   Handlebars.registerHelper('duration', function (context, block) {
     if (context && context.hash) {
-      block = _.cloneDeep(context);
+      block = cloneDeep(context);
       context = 0;
     }
     var duration = moment.duration(context);

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     }
   ],
   "dependencies": {
-    "moment": "~2.0.0",
-    "lodash": "~2.2.1"
+    "lodash.clonedeep": "^4.5.0",
+    "moment": "~2.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-assemble": "^0.1.13",
     "grunt-contrib-jshint": "~0.6.0",
-    "grunt-readme": "~0.1.9",
-    "grunt-assemble": "^0.1.13"
+    "grunt-readme": "~0.1.9"
   },
   "keywords": [
     "assemble",


### PR DESCRIPTION
Only one function is used from lodash, importing only that saves a bit of bundle size.